### PR TITLE
Fix bug where AsyncSeq.skipWhile skips an extra item

### DIFF
--- a/src/FSharpx.Async/AsyncSeq.fs
+++ b/src/FSharpx.Async/AsyncSeq.fs
@@ -439,10 +439,10 @@ module AsyncSeq =
   let rec skipWhileAsync p (input : AsyncSeq<'T>) : AsyncSeq<_> = async {
     let! v = input
     match v with
-    | Cons(h, t) -> 
+    | Cons(h, t) ->
         let! res = p h
         if res then return! skipWhileAsync p t
-        else return! t
+        else return v
     | Nil -> return Nil }
 
   /// Returns elements from an asynchronous sequence while the specified 

--- a/tests/FSharpx.Async.Tests/AsyncSeqTests.fs
+++ b/tests/FSharpx.Async.Tests/AsyncSeqTests.fs
@@ -1,0 +1,15 @@
+﻿module AsyncSeqTests
+
+open NUnit.Framework
+open FSharpx.Control
+
+[<Test>]
+let ``skipping should return all elements after the first non-match``() =
+    let expected = [ 3; 4 ]
+    let result = 
+        [ 1; 2; 3; 4 ] 
+        |> AsyncSeq.ofSeq 
+        |> AsyncSeq.skipWhile (fun i -> i <= 2) 
+        |> AsyncSeq.toBlockingSeq 
+        |> Seq.toList
+    Assert.AreEqual(expected, result)

--- a/tests/FSharpx.Async.Tests/FSharpx.Async.Tests.fsproj
+++ b/tests/FSharpx.Async.Tests/FSharpx.Async.Tests.fsproj
@@ -58,6 +58,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>
     <Compile Include="AsyncTest.fs" />
+    <Compile Include="AsyncSeqTests.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Added test to verify issue.
- Fix: When the condition no longer holds, return the current head as
  well as the AsyncSeq tail.
