### PR TITLE
AsyncSeq.toBlockingSeq does not hung forever if an exception is thrown and reraise it outside

### DIFF
--- a/tests/FSharpx.Async.Tests/AsyncSeqTests.fs
+++ b/tests/FSharpx.Async.Tests/AsyncSeqTests.fs
@@ -2,6 +2,7 @@
 
 open NUnit.Framework
 open FSharpx.Control
+open System
 
 [<Test>]
 let ``skipping should return all elements after the first non-match``() =
@@ -99,3 +100,11 @@ let ``AsyncSeq.bufferByCount``() =
   let s' = s |> AsyncSeq.bufferByCount 2 |> AsyncSeq.toList |> Async.RunSynchronously
 
   Assert.True(([[|1;2|];[|3;4|]] = s'))
+
+[<Test>]
+let ``AsyncSeq.toBlockingSeq does not hung forever and rethrows exception``() =
+  let s = asyncSeq {
+      yield 1
+      failwith "error"
+  }
+  Assert.Throws<AggregateException>(fun _ -> s |> AsyncSeq.toBlockingSeq |> Seq.toList |> ignore) |> ignore


### PR DESCRIPTION
The bug:

``` fsharp
asyncSeq {
    yield 1
    failwith "error"    
} 
|> AsyncSeq.toBlockingSeq
|> Seq.iter (printfn "%A")

output: 1, then hungs forever
```

Now the output is like this:

``` fsharp
1

Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.Exception: error
   at Microsoft.FSharp.Core.Operators.Raise[T](Exception exn)
   at FSharpx.Control.AsyncSeq.iterator@385-5.Invoke(Unit _arg2) in L:\github\FSharpx.Async\src\FSharpx.Async\AsyncSeq.f
s:line 385
   at Microsoft.FSharp.Control.AsyncBuilderImpl.args@787-1.Invoke(a a)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at FSharpx.Control.AsyncSeq.loop@390-33.GenerateNext(IEnumerable`1& next) in L:\github\FSharpx.Async\src\FSharpx.Asyn
c\AsyncSeq.fs:line 391
   at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1.MoveNextImpl()
   at Microsoft.FSharp.Collections.SeqModule.Iterate[T](FSharpFunc`2 action, IEnumerable`1 source)
   at Program.main(String[] _arg1) in L:\github\FSharpx.Async\ConsoleApplication1\Program.fs:line 5
```
