### PR TITLE
Add ResultChannel class and fix multiple continuation calls for AwaitObservable

### DIFF
--- a/src/FSharpx.Async/FSharpx.Async.fsproj
+++ b/src/FSharpx.Async/FSharpx.Async.fsproj
@@ -70,6 +70,7 @@
     <Compile Include="CircularQueueAgent.fs" />
     <Compile Include="ConcurrentSetAgent.fs" />
     <Compile Include="SlidingWindowAgent.fs" />
+    <Compile Include="ResultChannel.fs" />
     <Compile Include="Observable.fs" />
     <Compile Include="Async.fs" />
     <Compile Include="AsyncOperations.fsi" />

--- a/src/FSharpx.Async/Observable.fs
+++ b/src/FSharpx.Async/Observable.fs
@@ -252,73 +252,39 @@ module Observable =
       /// Behaves like AwaitObservable, but calls the specified guarding function
       /// after a subscriber is registered with the observable.
       static member GuardedAwaitObservable (ev1:IObservable<'T1>) guardFunction =
-          let removeObj : IDisposable option ref = ref None
-          let removeLock = new obj()
-          let setRemover r = 
-              lock removeLock (fun () -> removeObj := Some r)
-          let remove() =
-              lock removeLock (fun () ->
-                  match !removeObj with
-                  | Some d -> removeObj := None
-                              d.Dispose()
-                  | None   -> ())
-          synchronize (fun f ->
-          let workflow =
-              Async.FromContinuations((fun (cont,econt,ccont) ->
-                  let rec finish cont value =
-                      remove()
-                      f (fun () -> cont value)
-                  setRemover <|
-                      ev1.Subscribe
-                          ({ new IObserver<_> with
-                              member x.OnNext(v) = finish cont v
-                              member x.OnError(e) = finish econt e
-                              member x.OnCompleted() =
-                                  let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
-                                  finish ccont (new System.OperationCanceledException(msg)) })
-                  guardFunction() ))
           async {
-              let! cToken = Async.CancellationToken
-              let token : CancellationToken = cToken
-              use registration = token.Register((fun _ -> remove()), null)
-              return! workflow
-          })
+              let! token = Async.CancellationToken // capture the current cancellation token
+              return! Async.FromContinuations(fun (cont, econt, ccont) ->
+                  // start a new mailbox processor which will await the result
+                  Agent.Start((fun (mailbox : Agent<Choice<'T1, exn, OperationCanceledException>>) ->
+                      async {
+                          // register a callback with the cancellation token which posts a cancellation message
+                          use __ = token.Register((fun _ ->
+                              mailbox.Post (Choice3Of3 (new OperationCanceledException("The opeartion was cancelled.")))))
+          
+                          // subscribe to the observable: if an error occurs post an error message and post the result otherwise
+                          use __ = 
+                              ev1.Subscribe({ new IObserver<'T1> with
+                                  member __.OnNext result = mailbox.Post (Choice1Of3 result)
+                                  member __.OnError exn = mailbox.Post (Choice2Of3 exn)
+                                  member __.OnCompleted () =
+                                      let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
+                                      mailbox.Post (Choice3Of3 (new OperationCanceledException(msg))) })
+                          
+                          guardFunction() // call the guard function
+
+                          // wait for the first of these messages and call the appropriate continuation function
+                          let! message = mailbox.Receive()
+                          match message with
+                          | Choice1Of3 reply -> cont reply
+                          | Choice2Of3 exn -> econt exn
+                          | Choice3Of3 exn -> ccont exn })) |> ignore) }
 
       /// Creates an asynchronous workflow that will be resumed when the 
       /// specified observables produces a value. The workflow will return 
       /// the value produced by the observable.
-      static member AwaitObservable(observable : IObservable<'T1>) =
-          let removeObj : IDisposable option ref = ref None
-          let removeLock = new obj()
-          let setRemover r = 
-              lock removeLock (fun () -> removeObj := Some r)
-          let remove() =
-              lock removeLock (fun () ->
-                  match !removeObj with
-                  | Some d -> removeObj := None
-                              d.Dispose()
-                  | None   -> ())
-          synchronize (fun f ->
-          let workflow =
-              Async.FromContinuations((fun (cont,econt,ccont) ->
-                  let rec finish cont value =
-                      remove()
-                      f (fun () -> cont value)
-                  setRemover <|
-                      observable.Subscribe
-                          ({ new IObserver<_> with
-                              member x.OnNext(v) = finish cont v
-                              member x.OnError(e) = finish econt e
-                              member x.OnCompleted() =
-                                  let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
-                                  finish ccont (new System.OperationCanceledException(msg)) })
-                  () ))
-          async {
-              let! cToken = Async.CancellationToken
-              let token : CancellationToken = cToken
-              use registration = token.Register((fun _ -> remove()), null)
-              return! workflow
-          })
+      static member AwaitObservable(ev1 : IObservable<'T1>) =
+          Async.GuardedAwaitObservable ev1 ignore
   
       /// Creates an asynchronous workflow that will be resumed when the 
       /// first of the specified two observables produces a value. The 

--- a/src/FSharpx.Async/ResultChannel.fs
+++ b/src/FSharpx.Async/ResultChannel.fs
@@ -1,0 +1,66 @@
+﻿namespace FSharpx.Control
+
+/// A single-fire result channel which can be used to register a result and await it asynchronously.
+type ResultChannel<'T>() =               
+    let mutable result = None   // result is None until one is registered
+    let mutable savedConts = [] // list of continuations which will be applied to the result
+    let syncRoot = new obj()    // all writes of result are protected by a lock on syncRoot
+
+    /// Record the result, starting any registered continuations.
+    member channel.RegisterResult (res : 'T) =
+        let grabbedConts = // grab saved continuations and register the result
+            lock syncRoot (fun () ->
+                if channel.ResultAvailable then // if a result is already saved the raise an error
+                    failwith "Multiple results registered for result channel."
+                else // otherwise save the result and return the saved continuations
+                    result <- Some res
+                    List.rev savedConts)
+
+        // run all the grabbed continuations with the provided result
+        grabbedConts |> List.iter (fun cont -> cont res)
+
+    /// Check if a result has been registered with the channel.
+    member channel.ResultAvailable = result.IsSome
+
+    /// Wait for a result to be registered on the channel asynchronously.
+    member channel.AwaitResult () = async {
+        let! ct = Async.CancellationToken // capture the current cancellation token
+        
+        // create a flag which indicates whether a continuation has been called (either cancellation
+        // or success, and protect access under a lock; the performCont function sets the flag to true
+        // if it wasn't already set and returns a boolen indicating whether a continuation should run
+        let performCont = 
+            let continued = ref false
+            let localSync = obj()
+            (fun () ->
+                lock localSync (fun () ->
+                    if not !continued 
+                    then continued := true ; true
+                    else false))
+        
+        // wait for a result to be registered or cancellation to occur asynchronously
+        return! Async.FromContinuations(fun (cont, _, ccont) ->
+            let resOpt = 
+                lock syncRoot (fun () ->
+                    match result with
+                    | Some _ -> result // if a result is already set, capture it
+                    | None   ->
+                        // otherwise register a cancellation continuation and add the success continuation
+                        // to the saved continuations
+                        let reg = ct.Register(fun () -> 
+                            if performCont () then 
+                                ccont (new System.OperationCanceledException("The operation was canceled.")))
+                                
+                        let cont' = (fun res ->
+                            // modify the continuation to first check if cancellation has already been
+                            // performed and if not, also dispose the cancellation registration
+                            if performCont () then
+                                reg.Dispose()
+                                cont res)
+                        savedConts <- cont' :: savedConts
+                        None)
+
+            // if a result already exists, then call the result continuation outside the lock
+            match resOpt with
+            | Some res -> cont res
+            | None     -> ()) }

--- a/tests/FSharpx.Async.Tests/AwaitHelpers.fs
+++ b/tests/FSharpx.Async.Tests/AwaitHelpers.fs
@@ -1,0 +1,52 @@
+﻿namespace FSharpx.Control.Tests
+
+open System
+open System.Threading
+open System.Threading.Tasks
+
+type AwaiterResult<'a> =
+    | Timeout
+    | Canceled
+    | Result of 'a
+    | Error of exn
+    with 
+    override this.ToString() = 
+        match this with
+        | Timeout -> "Timeout"
+        | Canceled -> "Canceled"
+        | Result a -> a.ToString()
+        | Error err -> err.ToString()
+
+type Awaiter<'a> = TimeSpan -> 'a AwaiterResult
+
+[<AutoOpen>]
+module private AwaitHelpers =
+    
+    let startAsAwaiterWithCancellation (wf : Async<'a>, ct : CancellationToken option) : Awaiter<'a> =
+        let gotCanceled = new ManualResetEventSlim(false)
+        let withCancel = Async.TryCancelled(wf, fun _ -> gotCanceled.Set())
+        let task = 
+            match ct with 
+            | Some ct -> Async.StartAsTask (withCancel, cancellationToken = ct)
+            | None    -> Async.StartAsTask withCancel
+        let awaiter = fun (timeout : TimeSpan) ->
+            try
+                let completed = task.Wait(timeout)
+                if not completed && not gotCanceled.IsSet
+                    then Timeout 
+                elif task.IsCanceled || gotCanceled.IsSet
+                    then Canceled 
+                elif task.IsFaulted then 
+                    match task.Exception.InnerException with
+                    | :? TaskCanceledException -> Canceled
+                    | _                        -> Error task.Exception.InnerException
+                else
+                    Result task.Result
+            with
+            | :? AggregateException as aEx -> 
+                match aEx.InnerException with
+                | :? TaskCanceledException -> Canceled
+                | _                        -> Error aEx.InnerException
+        awaiter
+
+    let startAsAwaiter wf = startAsAwaiterWithCancellation (wf, None)

--- a/tests/FSharpx.Async.Tests/AwaitObservableTests.fs
+++ b/tests/FSharpx.Async.Tests/AwaitObservableTests.fs
@@ -1,0 +1,126 @@
+﻿namespace FSharpx.Control.Tests
+
+open System
+open System.Threading
+open System.Threading.Tasks
+
+open FSharpx.Control.Observable
+
+open NUnit.Framework
+
+[<TestFixture>]
+type ``AwaitObservable Tests``() = 
+
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable yields a value from the sources Next``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        source.Next("DONE")
+        source.Completed()
+        let result = awaiter(TimeSpan.FromSeconds(1.0))
+        Assert.AreEqual(Result "DONE", result)
+
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable yields the first value from the sources Next``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        source.Next("ONE")
+        source.Next("TWO")
+        source.Completed()
+        let result = awaiter(TimeSpan.FromSeconds(1.0))
+        Assert.AreEqual(Result "ONE", result)
+
+    [<Test; Repeat(10)>]
+    member test.``AwaitObservable is canceled if the source completes without a single result``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(0.1))
+        source.Completed()
+        let result = awaiter(TimeSpan.FromSeconds(0.1))
+        Assert.AreEqual(AwaiterResult<string>.Canceled, result)
+        
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable is unsubscribed from the source after a value was received``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        source.Next("Done")
+        source.AssertUnsubscribe(TimeSpan.FromSeconds(1.0))
+
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable is unsubscribed from the source after the source completes without a result``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        source.Completed()
+        source.AssertUnsubscribe(TimeSpan.FromSeconds(1.0))
+
+    [<Test>]
+    member test.``AwaitObservable is unsubscribed from the source after OnError was called``() =
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        source.Error(exn "test-error")
+        source.AssertUnsubscribe(TimeSpan.FromSeconds(1.0))
+
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable is unsubscribed from the source if it's resulting async-workflow gets cancelled``() =
+        let cts = new CancellationTokenSource()
+        let source = new ObservableMock<string>()
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiterWithCancellation (wf, Some cts.Token)
+        source.AssertSubscribtion(TimeSpan.FromSeconds(1.0))
+        cts.Cancel()
+        let result = awaiter (TimeSpan.FromSeconds(1.0)) 
+        Assert.AreEqual(AwaiterResult<string>.Canceled, result)
+        source.AssertUnsubscribe(TimeSpan.FromSeconds(1.0))
+    
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable yields the first value from a hot observable``() =
+        let source = { new IObservable<string> with
+            member __.Subscribe(observer) =
+                observer.OnNext("ONE")
+                observer.OnNext("TWO")
+                { new IDisposable with 
+                    member __.Dispose () = () } }
+
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        let result = awaiter(TimeSpan.FromSeconds(1.0))
+        Assert.AreEqual(Result "ONE", result)
+        
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable yields the first value from a hot observable with error``() =
+        let source = { new IObservable<string> with
+            member __.Subscribe(observer) =
+                observer.OnNext("ONE")
+                observer.OnError (exn "test-error")
+                { new IDisposable with 
+                    member __.Dispose () = () } }
+
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        let result = awaiter(TimeSpan.FromSeconds(1.0))
+        Assert.AreEqual(Result "ONE", result)
+            
+    [<Test; Repeat(1000)>]
+    member test.``AwaitObservable yields the first value from a hot observable which has completed``() =
+        let source = { new IObservable<string> with
+            member __.Subscribe(observer) =
+                observer.OnNext("ONE")
+                observer.OnCompleted()
+                { new IDisposable with 
+                    member __.Dispose () = () } }
+
+        let wf = Async.AwaitObservable source
+        let awaiter = startAsAwaiter wf
+        let result = awaiter(TimeSpan.FromSeconds(1.0))
+        Assert.AreEqual(Result "ONE", result)

--- a/tests/FSharpx.Async.Tests/FSharpx.Async.Tests.fsproj
+++ b/tests/FSharpx.Async.Tests/FSharpx.Async.Tests.fsproj
@@ -59,6 +59,9 @@
   <ItemGroup>
     <Compile Include="AsyncTest.fs" />
     <Compile Include="AsyncStreamTests.fs" />
+    <Compile Include="ObservableMock.fs" />
+    <Compile Include="AwaitHelpers.fs" />
+    <Compile Include="AwaitObservableTests.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/FSharpx.Async.Tests/ObservableMock.fs
+++ b/tests/FSharpx.Async.Tests/ObservableMock.fs
@@ -1,0 +1,40 @@
+﻿namespace FSharpx.Control.Tests
+
+open System
+open System.Threading
+open NUnit.Framework
+
+type ObservableMock<'a>() =
+
+    let _waitForSubscribtion = new ManualResetEventSlim(initialState = false)
+    let _waitForUnsubscribe = new ManualResetEventSlim(initialState = false)
+    let _connectedObserver : 'a IObserver option ref = ref None
+
+    let callObserver action =
+        match !_connectedObserver with
+        | Some obs -> action obs
+        | None     -> ()
+
+    member this.WaitForSubscribtionHandle = _waitForSubscribtion.WaitHandle
+    member this.WaitForSubscribtion(timeout : TimeSpan) = _waitForSubscribtion.Wait(timeout)
+    member this.AssertSubscribtion(timeout : TimeSpan) =
+        if not <| this.WaitForSubscribtion(timeout) then Assert.Fail("no subscribtion requested")
+
+    member this.WaitForUnsubscribeHandle = _waitForUnsubscribe.WaitHandle
+    member this.WaitForUnsubscribe(timeout : TimeSpan) = _waitForUnsubscribe.Wait(timeout)
+    member this.AssertUnsubscribe(timeout : TimeSpan) =
+        if not <| this.WaitForUnsubscribe(timeout) then Assert.Fail("a observer-subscription was not disposed")
+
+    member this.Next(value : 'a) = callObserver (fun obs -> obs.OnNext(value))
+    member this.Completed() = callObserver (fun obs -> obs.OnCompleted())
+    member this.Error(error : exn) = callObserver (fun obs -> obs.OnError(error))
+
+    interface IObservable<'a> with
+        member i.Subscribe(observer : IObserver<'a>) =
+            _connectedObserver := Some observer
+            _waitForSubscribtion.Set()
+            _waitForUnsubscribe.Reset()
+            { new IDisposable with 
+                member i.Dispose() = 
+                    _connectedObserver := None 
+                    _waitForUnsubscribe.Set() }


### PR DESCRIPTION
The previous implementation of Async.AwaitObservable fails for hot observables (which immediately call the OnNext event, potentially multiple times, on subscription). This issue is fixed here by introducing ResultChannel<'T> which can be used to post an result and await it asynchronously elsewhere. Also copied across some unit tests for AwaitObservable from the fsharpx project which are now passing reliably.
