### PR TITLE
Async.Cache should catch and bubble up exceptions

### DIFF
--- a/tests/FSharpx.Async.Tests/AsyncTest.fs
+++ b/tests/FSharpx.Async.Tests/AsyncTest.fs
@@ -51,3 +51,8 @@ let ``Parallel with throttle``() =
   let tasks = nums |> Array.map work
   let result = Async.ParallelWithThrottle 1 tasks
   Assert.AreEqual(nums, result |> Async.RunSynchronously)
+
+[<Test>]
+let ``Cache should catch and bubble up exceptions``() =
+  let workflow = async { invalidOp "fail" } |> Async.Cache
+  Assert.Throws<InvalidOperationException>(fun () -> workflow |> Async.RunSynchronously) |> ignore


### PR DESCRIPTION
Currently if the workflow being cached throws, the workflow returned by Async.Cache will never complete