### PR TITLE
Add BlockingQueueAgent#Dispose

### DIFF
--- a/src/FSharpx.Async/BlockingQueueAgent.fs
+++ b/src/FSharpx.Async/BlockingQueueAgent.fs
@@ -97,3 +97,7 @@ type BlockingQueueAgent<'T>(maxLength) =
 
     /// Gets the number of elements currently waiting in the queue.
     member x.Count = count
+
+    interface IDisposable with
+        member _.Dispose() =
+            (agent :> IDisposable).Dispose()


### PR DESCRIPTION
MailboxProcessor has a [dispose](https://github.com/dotnet/fsharp/pull/14929) function now, so BlockingQueueAgent should handle have one as well